### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,20 +11,20 @@
     <title>Vivica - AI Assistant</title>
     <meta name="description" content="Vivica - Your intelligent AI assistant" />
     <meta name="author" content="Lovable" />
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="/lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" type="image/png" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" type="image/png" />
 
     <meta property="og:title" content="Vivica - AI Assistant" />
     <meta property="og:description" content="Your intelligent AI assistant" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" />
+    <meta property="og:image" content="lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="/lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" />
+    <meta name="twitter:image" content="lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png" />
   </head>
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,20 +3,20 @@
   "name": "Vivica - AI Assistant",
   "short_name": "Vivica",
   "description": "Your intelligent AI assistant",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png",
+      "src": "lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png",
+      "src": "lovable-uploads/790c3ad0-f2a5-41ef-ac83-99cb6bdd3112.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ const manifest = JSON.parse(
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/vivica-chat-companion-63/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure base path for GitHub Pages
- use relative paths for manifest, icon and script
- update PWA manifest for relative start_url and icon paths

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68784c912d68832a8afd58debf6dbd7e