### PR TITLE
Fix theme switching with shared ThemeProvider

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
 
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { ThemeProvider } from './hooks/useTheme';
 
 // Remove PWA register for now to fix build error
 // import { registerSW } from 'virtual:pwa-register'
 // registerSW({ immediate: true })
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- introduce `ThemeProvider` context in `useTheme` and share theme state
- wrap application in `ThemeProvider`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878e34938a4832a907d43a8088836bf